### PR TITLE
Fix read-float handling of big-endian values

### DIFF
--- a/binaryio-lib/private/float.rkt
+++ b/binaryio-lib/private/float.rkt
@@ -12,4 +12,4 @@
 
 (define (read-float size [port (current-input-port)]
                     [big-endian? #t] #:who [who 'read-float])
-  (floating-point-bytes->real (read-bytes* size port #:who who)))
+  (floating-point-bytes->real (read-bytes* size port #:who who) big-endian?))

--- a/binaryio/info.rkt
+++ b/binaryio/info.rkt
@@ -7,7 +7,8 @@
 (define deps
   '(["base" #:version "6.3"]
     "binaryio-lib"
-    "rackunit-lib"))
+    "rackunit-lib"
+    "math-lib"))
 (define implies
   '("binaryio-lib"))
 (define build-deps

--- a/binaryio/test/float.rkt
+++ b/binaryio/test/float.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+(require rackunit
+         binaryio/float
+         racket/math
+         math/flonum)
+(provide (all-defined-out))
+
+(define PRINT? #f)
+
+(define (test-float val size be?)
+  (define-values (in out) (make-pipe))
+  (write-float val size out be?)
+  (check-equal? (read-float size in be?) (real->double-flonum val) "write read roundtrip"))
+
+;; For several constants and special values, test
+;; - roundtripping via write-float and read-float
+
+
+(for ([val (list 0.0 -0.0 pi +nan.0 +inf.0 -inf.0 +max.0 -max.0 +min.0 -min.0 epsilon.0)])
+  (test-case (format "Double-float constant ~e" val)
+    (when PRINT? (printf "testing double-float constant ~e\n" val))
+    (test-float val 8 #t)
+    (test-float val 8 #f)))
+
+(for ([val (list 0.0f0 -0.0f0 pi.f +nan.f +inf.f -inf.f)])
+  (test-case (format "single-float constant ~e" val)
+    (when PRINT? (printf "testing single-float constant ~e\n" val))
+    (test-float val 4 #t)
+    (test-float val 4 #f)))
+
+;; For many random floats between 0 and 1, exclusive, of varying sizes and endian-ness, test
+;; - roundtripping via write-float and read-float
+
+(for ([i (in-range 40)])
+   (define val (random))
+   (test-case (format "Random float ~e" val)
+     (when PRINT? (printf "testing random float ~e\n" val))
+     (test-float val 8 #t)
+     (test-float val 8 #f)
+     (test-float (real->single-flonum val) 4 #t)
+     (test-float (real->single-flonum val) 4 #f)))


### PR DESCRIPTION
I uncovered a bug in this library in the handling of big-endian values. `read-float` did not pass through the big-endian value to the underlying `floating-point-bytes->real` call.

This patch adds a basic set of tests for the floats, which fail under the current master. Then the simple fix to demonstrate the tests passing.