### PR TITLE
build: add missing dep on data-lib

### DIFF
--- a/binaryio-lib/info.rkt
+++ b/binaryio-lib/info.rkt
@@ -8,7 +8,8 @@
 
 (define version "1.3")
 (define collection "binaryio")
-(define deps '("base"))
+(define deps '("base"
+               "data-lib"))
 (define pkg-authors '(ryanc))
 (define license '(Apache-2.0 OR MIT))
 


### PR DESCRIPTION
`binaryio-lib` is a transitive dependency of one of the packages I have installed and I noticed my Racket builds started complaining about the undeclared dep (relatively) recently.