### PR TITLE
Fix `b-read-nul-terminated-bytes` failing to advance read counter

### DIFF
--- a/binaryio/test/reader.rkt
+++ b/binaryio/test/reader.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+(require rackunit
+         binaryio/reader)
+
+(test-case "b-read-nul-terminated-bytes advances the limit"
+  (define br (make-binary-reader (open-input-bytes #"hello\0world") #:limit 6))
+  (check-equal? (b-read-nul-terminated-bytes br) #"hello")
+  (check-equal? (b-get-limit br) 0))
+
+(test-case "b-read-nul-terminated-bytes errors if limit exceeded"
+  (define br (make-binary-reader (open-input-bytes #"hello\0world") #:limit 5))
+  (check-exn #rx"NUL terminator not found before current limit"
+             (lambda () (b-read-nul-terminated-bytes br))))


### PR DESCRIPTION
Fixes #3.

Additionally, this patch inserts an explicit check for whether the result of `peek-bytes-avail!` is zero, and if it is, it signals an error. Without the change, it is technically possible for a concurrent read to cause the function to spin forever. That is arguably not a bug given the documentation explicitly states the API is not thread safe, but it seems like probably nicer behavior, regardless.